### PR TITLE
Allow --jobs=1

### DIFF
--- a/programs/koinos_block_producer/main.cpp
+++ b/programs/koinos_block_producer/main.cpp
@@ -154,7 +154,7 @@ int main( int argc, char** argv )
       else if ( algorithm == POW_ALGORITHM )
       {
          LOG(info) << "Using " << POW_ALGORITHM << " algorithm";
-         KOINOS_ASSERT( jobs > 1, koinos::exception, "Jobs must be greater than 1 when using " POW_ALGORITHM " algorithm." );
+         KOINOS_ASSERT( jobs >= 1, koinos::exception, "Jobs must be at least 1 when using " POW_ALGORITHM " algorithm." );
          producer = std::make_unique< block_production::pow_producer >( main_context, production_context, client, work_groups );
          LOG(info) << "Using " << work_groups << " work groups";
       }


### PR DESCRIPTION
This assert triggers at startup on a single-core machine if you don't specify `--jobs`.