### PR TITLE
Use head block when calculating next quantum

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -17,5 +17,5 @@ if ! [[ -z $BUILD_DOCKER ]]; then
 
    cd koinos-integration-tests
    go get ./...
-   #./run.sh
+   ./run.sh
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -17,5 +17,5 @@ if ! [[ -z $BUILD_DOCKER ]]; then
 
    cd koinos-integration-tests
    go get ./...
-   ./run.sh
+   #./run.sh
 fi

--- a/libraries/block_production/block_producer.cpp
+++ b/libraries/block_production/block_producer.cpp
@@ -319,12 +319,16 @@ uint64_t block_producer::now()
       std::chrono::system_clock::now().time_since_epoch()
    ).count() );
 
-   uint64_t last_block_time = _last_block_time;
+   uint64_t last_block_time = _head_block_time.load();
 
    return last_block_time > now ? last_block_time : now;
 }
 
-void block_producer::on_block_accept( const broadcast::block_accepted& bam ) { }
+void block_producer::on_block_accept( const broadcast::block_accepted& bam )
+{
+   if ( bam.head() )
+      _head_block_time.store( bam.block().header().timestamp() );
+}
 
 void block_producer::on_gossip_status( const broadcast::gossip_status& gs )
 {

--- a/libraries/block_production/include/koinos/block_production/block_producer.hpp
+++ b/libraries/block_production/include/koinos/block_production/block_producer.hpp
@@ -58,7 +58,7 @@ protected:
    boost::asio::signal_set           _signals;
    std::shared_ptr< mq::client >     _rpc_client;
    const crypto::private_key         _signing_key;
-   std::atomic< int64_t >            _last_block_time = 0;
+   std::atomic< int64_t >            _head_block_time = 0;
    std::atomic< bool >               _halted = true;
    const uint64_t                    _resources_lower_bound;
    const uint64_t                    _resources_upper_bound;

--- a/libraries/block_production/include/koinos/block_production/block_producer.hpp
+++ b/libraries/block_production/include/koinos/block_production/block_producer.hpp
@@ -58,7 +58,7 @@ protected:
    boost::asio::signal_set           _signals;
    std::shared_ptr< mq::client >     _rpc_client;
    const crypto::private_key         _signing_key;
-   std::atomic< int64_t >            _head_block_time = 0;
+   std::atomic< uint64_t >           _head_block_time = 0;
    std::atomic< bool >               _halted = true;
    const uint64_t                    _resources_lower_bound;
    const uint64_t                    _resources_upper_bound;

--- a/libraries/block_production/pob_producer.cpp
+++ b/libraries/block_production/pob_producer.cpp
@@ -128,7 +128,7 @@ void pob_producer::produce( const boost::system::error_code& ec, std::shared_ptr
 
 std::chrono::system_clock::time_point pob_producer::next_time_quantum( std::chrono::system_clock::time_point tp )
 {
-   auto time_point = std::max( tp, std::chrono::system_clock::now() );
+   auto time_point = std::max( tp, std::chrono::system_clock::time_point{ std::chrono::milliseconds{ _head_block_time.load() } } );
    auto time_ms    = std::chrono::duration_cast< std::chrono::milliseconds >( time_point.time_since_epoch() ).count();
    auto remainder  = time_ms % 10;
    time_ms        += 10 - remainder;


### PR DESCRIPTION
## Brief description
Rather than using `std::chrono::system_clock::now()` we should use `head_block_time` to capture all possible quanta.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests
