### PR TITLE
Clean up PoB block production logs

### DIFF
--- a/libraries/block_production/block_producer.cpp
+++ b/libraries/block_production/block_producer.cpp
@@ -216,7 +216,7 @@ void block_producer::fill_block( protocol::block& b )
       }
    }
 
-   LOG(info) << "Created block containing " << b.transactions_size() << " " << ( b.transactions_size() == 1 ? "transaction" : "transactions" ) << " utilizing approximately "
+   LOG(debug) << "Created block containing " << b.transactions_size() << " " << ( b.transactions_size() == 1 ? "transaction" : "transactions" ) << " utilizing approximately "
              << disk_storage_count << "/" << block_resource_limits.disk_storage_limit() << " disk, "
              << network_bandwidth_count << "/" << block_resource_limits.network_bandwidth_limit() << " network, "
              << compute_bandwidth_count << "/" << block_resource_limits.compute_bandwidth_limit() << " compute";
@@ -293,7 +293,9 @@ bool block_producer::submit_block( protocol::block& b )
 
    KOINOS_ASSERT( resp.has_submit_block(), rpc_failure, "unexpected RPC response while submitting block: ${r}", ("r", resp) );
 
-   LOG(info) << "Produced block - Height: " << b.header().height() << ", ID: " << util::converter::to< crypto::multihash >( b.id() );
+   auto num_transactions = b.transactions_size();
+
+   LOG(info) << "Produced block - Height: " << b.header().height() << ", ID: " << util::converter::to< crypto::multihash >( b.id() ) << " (" << num_transactions << ( num_transactions == 1 ? " transaction)" : " transactions)" );
    return false;
 }
 

--- a/libraries/block_production/include/koinos/block_production/pob_producer.hpp
+++ b/libraries/block_production/include/koinos/block_production/pob_producer.hpp
@@ -74,6 +74,7 @@ private:
    const uint32_t                                _symbol_entry_point = 0xb76a7ca1;
    std::optional< burn_auxiliary_bundle >        _auxiliary_data;
    std::mutex                                    _mutex;
+   std::chrono::system_clock::time_point         _last_vhp_log;
 
    void next_auxiliary_bundle();
    std::shared_ptr< burn_production_bundle > next_bundle();


### PR DESCRIPTION
Resolves <!-- Issue number(s) in the form #1 or org/repo#1 -->

## Brief description

Cleans up the block production logs for PoB, removing excessive and redundant information already logged by other microservices.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

```
2022-10-25 09:26:03.289222 (block_producer.Koinos) [block_producer.cpp:86] <info>: Gossip is enabled, starting block production
2022-10-25 09:26:03.297647 (block_producer.Koinos) [pob_producer.cpp:327] <info>: Target block interval: 3000ms
2022-10-25 09:26:03.297737 (block_producer.Koinos) [pob_producer.cpp:328] <info>: Quantum length: 10ms
2022-10-25 09:26:03.311425 (block_producer.Koinos) [pob_producer.cpp:352] <info>: Estimated total VHP producing: 8980529.76937794 VHP
2022-10-25 09:26:03.311618 (block_producer.Koinos) [pob_producer.cpp:355] <info>: Producing with 2827286.33609195 VHP
2022-10-25 09:26:03.320741 (block_producer.Koinos) [main.cpp:381] <info>: Established request handler connection to the AMQP server
2022-10-25 09:26:03.320827 (block_producer.Koinos) [main.cpp:383] <info>: Using 8 jobs
2022-10-25 09:26:03.320887 (block_producer.Koinos) [main.cpp:384] <info>: Starting block producer...
2022-10-25 09:26:35.242441 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767193, ID: 0x12203f456d03676ae9f9b76d2c425e4c35122248afa32f064436f2cad1e9e8dd633f (0 transactions)
2022-10-25 09:26:49.687484 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767198, ID: 0x12204405d1668dfc01fca6d1609ad550e5cb73a8697bffc3cf50b919281c6cc5cf5c (0 transactions)
2022-10-25 09:26:51.323034 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767200, ID: 0x122021e64d9dc5750ffcbcb5ac5971e43563cbd378bb263d1cb038fa5931cb0f2d4a (0 transactions)
2022-10-25 09:26:52.223418 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767202, ID: 0x1220b5d1f299bb806aff1e80569d889b6c52936fdc372c6b5533a9f693b36bf9eefc (0 transactions)
2022-10-25 09:26:52.634759 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767203, ID: 0x1220675c62595c5a887fe0cae82f837eae5a1881d4a73b4fd6a8f2f811f0823ec3ab (0 transactions)
2022-10-25 09:26:52.973994 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767204, ID: 0x122040712f92d7c677da15773e075d3fc5692a50f2703317d72b3027601ba0d20414 (0 transactions)
2022-10-25 09:27:02.408705 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767205, ID: 0x122001792d529772b2298366d66f303d92d20303c81989e265734a09b55ba8797261 (0 transactions)
2022-10-25 09:27:03.618596 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767206, ID: 0x12208ed4f61499e683dab40215ece3693c7b9ca29dcdb5eec9181a7fc4bc97456611 (0 transactions)
2022-10-25 09:27:03.629861 (block_producer.Koinos) [pob_producer.cpp:352] <info>: Estimated total VHP producing: 9028859.28156689 VHP
2022-10-25 09:27:03.629949 (block_producer.Koinos) [pob_producer.cpp:355] <info>: Producing with 2827265.77679206 VHP
2022-10-25 09:27:21.005895 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767213, ID: 0x12206f6401ff9a57546bccfa072a2163909fda5b67c5c53a822b2445ce78b5a51211 (1 transaction)
2022-10-25 09:27:27.317756 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767217, ID: 0x122053409a53c7dbdedda71bc5bdb3f31854f45d190fab6be07d0b8911c76ad16131 (0 transactions)
2022-10-25 09:27:42.059970 (block_producer.Koinos) [block_producer.cpp:298] <info>: Produced block - Height: 1767221, ID: 0x122063f634bdc64fe9907b727688d82599ad60fbe5ccee46a872febbd944595a70b7 (0 transactions)
```