### PR TITLE
Bump MQ to v1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ HunterGate(
    LOCAL
 )
 
-project(koinos_block_producer VERSION 1.0.0 LANGUAGES CXX C)
+project(koinos_block_producer VERSION 1.0.1 LANGUAGES CXX C)
 add_compile_definitions(KOINOS_MAJOR_VERSION=${PROJECT_VERSION_MAJOR})
 add_compile_definitions(KOINOS_MINOR_VERSION=${PROJECT_VERSION_MINOR})
 add_compile_definitions(KOINOS_PATCH_VERSION=${PROJECT_VERSION_PATCH})


### PR DESCRIPTION
Resolves #128.

## Brief description
Bumps MQ to v1.0.1.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

