### PR TITLE
Implement the usage of `propose_block` RPC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,26 @@ jobs:
       env:
         - TAG=`if [ $TRAVIS_BRANCH == "master" ]; then echo -n latest; else echo -n $TRAVIS_BRANCH; fi`
         - BLOCK_PRODUCER_TAG=$TAG
+      before_install:
+        - sudo systemctl stop docker.service && sudo systemctl stop docker.socket
+        - sudo apt-get install ca-certificates curl
+        - sudo install -m 0755 -d /etc/apt/keyrings
+        - sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        - sudo chmod a+r /etc/apt/keyrings/docker.asc
+        - |
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        - sudo apt-get update
       install:
+        - sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
         - git clone https://github.com/koinos/koinos-integration-tests.git
         - pushd koinos-integration-tests
         - go get ./...
         - popd
       before_script:
+        - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
         - cp -R ~/.ccache ./ccache
         - docker build . -t build --target builder
         - docker build . -t $TRAVIS_REPO_SLUG:$TAG
@@ -83,7 +97,6 @@ jobs:
       after_success:
         - |
           if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-            echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
             docker push $TRAVIS_REPO_SLUG:$TAG
           fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   koinos_cmake
   GIT_REPOSITORY https://github.com/koinos/koinos-cmake.git
-  GIT_TAG        v1.0.0)
+  GIT_TAG        v1.0.1)
 FetchContent_MakeAvailable(koinos_cmake)
 
 include("${koinos_cmake_SOURCE_DIR}/Koinos.cmake")

--- a/src/koinos/block_production/block_producer.hpp
+++ b/src/koinos/block_production/block_producer.hpp
@@ -17,6 +17,7 @@
 namespace koinos::block_production {
 
 KOINOS_DECLARE_EXCEPTION( block_production_exception );
+KOINOS_DECLARE_DERIVED_EXCEPTION( unexpected_response, block_production_exception );
 KOINOS_DECLARE_DERIVED_EXCEPTION( rpc_failure, block_production_exception );
 KOINOS_DECLARE_DERIVED_EXCEPTION( timestamp_overflow, block_production_exception );
 KOINOS_DECLARE_DERIVED_EXCEPTION( nonce_failure, block_production_exception );
@@ -67,7 +68,6 @@ protected:
 private:
   void on_run( const boost::system::error_code& ec );
   void fill_block( protocol::block& b );
-  void trim_block( protocol::block& b, const std::string& trx_id );
   void
   set_merkle_roots( protocol::block&, crypto::multicodec code, crypto::digest_size size = crypto::digest_size( 0 ) );
   uint64_t now();


### PR DESCRIPTION
Resolves #145.

## Brief description
Implements the usage of `propose_block` RPC. The logic should be as follows:
1. If there is an error, it is unrecoverable -- log error details and try again from scratch.
2. If there is a response without a receipt, there should be failed transactions; prune them and re-submit.
3. If there is a response with a receipt, the block has succeeded, progress normally.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
